### PR TITLE
Updating Karabiner to the latest release

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -5,7 +5,7 @@
 # $cli - location of command-line interface to the application
 # $private_xml_path - location of private.xml
 class karabiner::config {
-  $version = '10.6.0'
+  $version = '10.10.0'
   $base_url = 'https://pqrs.org/osx/karabiner/files'
   $dmg_url = "${base_url}/Karabiner-${version}.dmg"
   $app = '/Applications/Karabiner.app'

--- a/spec/classes/karabiner_spec.rb
+++ b/spec/classes/karabiner_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'karabiner' do
-  let(:version) { '10.6.0' }
+  let(:version) { '10.10.0' }
 
   it do
     should contain_class('karabiner::config')

--- a/spec/classes/login_item_spec.rb
+++ b/spec/classes/login_item_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'karabiner::login_item' do
-  let(:version) { '10.6.0' }
+  let(:version) { '10.10.0' }
 
   it do
     should contain_class('karabiner::config')
@@ -49,4 +49,3 @@ describe 'karabiner::login_item' do
     end
   end
 end
-

--- a/spec/defines/exec_spec.rb
+++ b/spec/defines/exec_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'karabiner::exec' do
-  let(:version) { '10.6.0' }
+  let(:version) { '10.10.0' }
   cli = '/Applications/Karabiner.app/Contents/Library/bin/karabiner'
 
   context 'with command list' do


### PR DESCRIPTION
Karabiner 10.10.0 is out. The website only lists 10.9, but the update
mechanism within the app is already pushing 10.10. This will install it
by default.